### PR TITLE
Fix Item 11: use 'git rm -rf .' instead of '*' to properly delete all…

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Let's suppose our repo
 
 And we want to restore the repo to the C2 commit using the following commands:
 ```bash
-$ git rm -rf *
+$ git rm -rf .         # includes hidden files (e.g., .gitignore, .env, etc.)
 $ git checkout C2 . #note the dot at the end of git checkout
 $ git commit -m 'Restore to C2'
 ```


### PR DESCRIPTION
While following Item 11 to restore a repo to commit C2, I encountered an issue:

    $ git rm -rf *
    fatal: pathspec 'some-folder' did not match any files

![image](https://github.com/user-attachments/assets/f34272dc-57a3-4506-a09f-5622e448c364)

This happens because '*' expands only visible files and folders, and may skip hidden files (like .gitignore, .env) or those excluded via .gitignore.

This PR replaces 'git rm -rf *' with 'git rm -rf .', which is more consistent and reliably deletes all files (except .git/) regardless of visibility or ignore rules.


See the screenshots below for the error, the fix using git rm -rf ., and the successful execution of the remaining steps.

![image](https://github.com/user-attachments/assets/fcd750e3-b5a9-4b81-bc03-f871044d51de)

![image](https://github.com/user-attachments/assets/05137456-4993-4cad-b646-42df38eee59b)